### PR TITLE
add create_type_stmt and alter_type_stmt

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -60,7 +60,7 @@ stmt_list ::= ( stmt SEMI ) * {
   mixin="com.alecstrong.sql.psi.core.psi.mixins.SqlStmtListMixin"
   pin(".*")=1
 }
-stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( extension_stmt | alter_table_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt | create_view_stmt |
+stmt ::= [ EXPLAIN [ QUERY PLAN ] ] ( extension_stmt | alter_table_stmt | alter_type_stmt | analyze_stmt | attach_stmt | begin_stmt | commit_stmt | create_index_stmt | create_table_stmt | create_trigger_stmt| create_type_stmt | create_view_stmt |
                                           create_virtual_table_stmt | delete_stmt_limited | detach_stmt | drop_index_stmt | drop_table_stmt | drop_trigger_stmt | drop_view_stmt | insert_stmt |
                                           pragma_stmt | reindex_stmt | release_stmt | rollback_stmt | savepoint_stmt | compound_select_stmt | update_stmt_limited | vacuum_stmt
                                         ) {
@@ -234,6 +234,9 @@ expr ::= ( other_expr
 other_expr ::= extension_expr
 extension_expr ::= FAKE_EXTENSION
 extension_stmt ::= FAKE_EXTENSION
+alter_type_stmt ::= FAKE_EXTENSION
+create_type_stmt ::= FAKE_EXTENSION
+
 multi_column_expr ::= multi_column_expression ( LT | LTE | GT | GTE ) multi_column_expression {
   pin = 2
 }


### PR DESCRIPTION
Explicitly add fake extension points for dialects to implement

This is added to sql-psi core as needs to be referenced in sql-delight to use in Database schema generation

e.g `create_type_stmt` psi elements must be ordered before `create_table_stmt` elements 

closes #533 