### PR TITLE
Add element tree to compileFile

### DIFF
--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -15,7 +15,13 @@ fun compileFile(text: String, fileName: String = "temp.s", predefined: List<Pred
   val environment = TestHeadlessParser.build(
     root = directory.path,
     annotator = { element, message ->
-      throw AssertionError("at ${element.textOffset} : $message")
+      val tree = buildString {
+        element.containingFile.printTree {
+          append("  ")
+          append(it)
+        }
+      }
+      throw AssertionError("at ${element.textOffset} : $message\n${tree}")
     },
     predefinedTables = predefined,
   )

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -21,7 +21,7 @@ fun compileFile(text: String, fileName: String = "temp.s", predefined: List<Pred
           append(it)
         }
       }
-      throw AssertionError("at ${element.textOffset} : $message\n${tree}")
+      throw AssertionError("at ${element.textOffset} : $message\n$tree")
     },
     predefinedTables = predefined,
   )

--- a/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/test-fixtures/src/main/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -104,13 +104,6 @@ abstract class FixturesTest(
     newRoot.deleteRecursively()
   }
 
-  private fun PsiElement.printTree(printer: (String) -> Unit) {
-    printer("$this\n")
-    children.forEach { child ->
-      child.printTree { printer("  $it") }
-    }
-  }
-
   private fun File.replaceKeywords() {
     if (isDirectory) {
       listFiles()?.forEach { it.replaceKeywords() }
@@ -171,3 +164,10 @@ private fun formatErrorList(errors: List<String>): String {
 private val inlineErrorRegex = "^--\\s*error\\[col (\\d+)]:(.+)$".toRegex(RegexOption.MULTILINE)
 
 private fun String.splitLines() = split("\\r?\\n".toRegex())
+
+internal fun PsiElement.printTree(printer: (String) -> Unit) {
+  printer("$this\n")
+  children.forEach { child ->
+    child.printTree { printer("  $it") }
+  }
+}


### PR DESCRIPTION
The tree is helpful for `compileFile` due to missing line breaks.