### PR TITLE
Check parent cte tablesAvailable

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/InsertStmtMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/InsertStmtMixin.kt
@@ -1,7 +1,10 @@
 package com.alecstrong.sql.psi.core.psi.mixins
 
+import com.alecstrong.sql.psi.core.psi.LazyQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
+import com.alecstrong.sql.psi.core.psi.SqlWithClause
+import com.alecstrong.sql.psi.core.psi.SqlWithClauseAuxiliaryStmt
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 
@@ -23,5 +26,12 @@ internal abstract class InsertStmtMixin(
     }
 
     return super.queryAvailable(child)
+  }
+
+  override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
+    val tablesAvailable = super.tablesAvailable(child)
+    val withClauseAuxiliaryStmts = parent as? SqlWithClauseAuxiliaryStmt ?: return tablesAvailable
+    val withClause = withClauseAuxiliaryStmts.parent as SqlWithClause
+    return tablesAvailable + withClause.tablesExposed()
   }
 }


### PR DESCRIPTION
🏗️ In Progress 🚧

Instead of inherited behaviour check if CTE parent is available in context

Have tested with SqlDelight and passes all tests

closes #543