### PR TITLE
Extend base contributors to multiple files

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlFileBase.kt
@@ -128,8 +128,13 @@ abstract class SqlFileBase(
         }
       }
 
-      baseContributorFile()?.contributors()?.let { contributors ->
-        orderedContributors[0] = linkedSetOf(*contributors.toTypedArray())
+      val baseContributorFiles = baseContributorFiles()
+      for ((baseContributorIndex, baseContributor) in baseContributorFiles.withIndex()) {
+        // Put the last file to index 0, and the previous files to previous index.
+        val orderedIndex = -baseContributorFiles.lastIndex + baseContributorIndex.toLong()
+        baseContributor.contributors()?.let { contributors ->
+          orderedContributors[orderedIndex] = linkedSetOf(elements = contributors.toTypedArray())
+        }
       }
 
       orderedContributors.forEach { (_, contributors) ->
@@ -147,9 +152,10 @@ abstract class SqlFileBase(
   private fun contributors() = sqlStmtList?.stmtList?.mapNotNull { it.firstChild as? SchemaContributor }
 
   /**
-   * An optional file which can be used for extra Schema Contributors that are unindexed.
+   * Optional files which can be used for extra Schema Contributors that are unindexed.
+   * The files are added to the schema in the provided order.
    */
-  protected open fun baseContributorFile(): SqlFileBase? = null
+  protected open fun baseContributorFiles(): List<SqlFileBase> = emptyList()
 
   protected open fun searchScope(): GlobalSearchScope {
     return GlobalSearchScope.everythingScope(project)


### PR DESCRIPTION
Includes #549, so merge these PRs first to have a clean history.

Use-case system tables: Instead hacking sql-psi I want to switch to the base contributor, which is already supported. To support inheritance (the existing db schema file used in sqldelight), we should switch to a list executing the files in the provided order.