### PR TITLE
Rework system tables

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlCoreEnvironment.kt
@@ -56,10 +56,6 @@ private class ApplicationEnvironment {
   }
 }
 
-data class PredefinedTable(val packageName: String, val simpleFileName: String, val content: String) {
-  val fileName = "$packageName.$simpleFileName"
-}
-
 open class SqlCoreEnvironment(
   sourceFolders: List<File>,
   dependencies: List<File>,

--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/TablesExposedTest.kt
@@ -30,15 +30,11 @@ class TablesExposedTest {
       |ALTER TABLE test3 RENAME TO test5;
       """.trimMargin(),
       predefined = listOf(
-        PredefinedTable(
-          "predefined",
-          "1.predefined",
-          """
-      |CREATE TABLE predefined (
-      |  id TEXT NOT NULL
-      |);
-          """.trimMargin(),
-        ),
+        """
+        |CREATE TABLE predefined (
+        |  id TEXT NOT NULL
+        |);
+        """.trimMargin(),
       ),
     ) { (_, file) ->
 
@@ -77,15 +73,11 @@ class TablesExposedTest {
       |ALTER TABLE test3 RENAME TO test5;
       """.trimMargin(),
       predefined = listOf(
-        PredefinedTable(
-          "predefined",
-          "1.predefined",
-          """
-      |CREATE TABLE predefined (
-      |  id TEXT NOT NULL
-      |);
-          """.trimMargin(),
-        ),
+        """
+        |CREATE TABLE predefined (
+        |  id TEXT NOT NULL
+        |);
+        """.trimMargin(),
       ),
     ) { (_, file) ->
 

--- a/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
+++ b/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/CompileFile.kt
@@ -1,6 +1,5 @@
 package com.alecstrong.sql.psi.test.fixtures
 
-import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.core.CoreApplicationEnvironment
 import java.io.File
@@ -10,7 +9,7 @@ fun compileFile(
   // language=sql
   text: String,
   customInit: CoreApplicationEnvironment.() -> Unit = { },
-  predefined: List<PredefinedTable> = emptyList(),
+  predefined: List<String> = emptyList(),
   action: (SqlFileBase) -> Unit,
 ) {
   compileFiles(text, predefined = predefined, customInit = customInit) {
@@ -21,7 +20,7 @@ fun compileFile(
 fun compileFiles(
   vararg files: String,
   customInit: CoreApplicationEnvironment.() -> Unit = { },
-  predefined: List<PredefinedTable> = emptyList(),
+  predefined: List<String> = emptyList(),
   action: (List<SqlFileBase>) -> Unit,
 ) {
   val directory = Files.createTempDirectory("sql-psi").toFile()

--- a/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -1,6 +1,5 @@
 package com.alecstrong.sql.psi.test.fixtures
 
-import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
@@ -13,7 +12,7 @@ import java.util.jar.JarFile
 abstract class FixturesTest(
   val name: String,
   val fixtureRoot: File,
-  val predefinedTables: List<PredefinedTable> = emptyList(),
+  val predefinedTables: List<String> = emptyList(),
 ) {
   protected open val replaceRules: Array<Pair<String, String>> = emptyArray()
 
@@ -41,13 +40,7 @@ abstract class FixturesTest(
         val offsetInLine = element.textOffset - document.getLineStartOffset(lineNum)
         errors.add("$name line ${lineNum + 1}:$offsetInLine - $s")
       },
-      predefinedTables = (
-        newRoot.listFiles { _, name ->
-          name.endsWith(".predefined")
-        }?.map {
-          PredefinedTable("", it.nameWithoutExtension, it.readText())
-        } ?: emptyList()
-        ) + predefinedTables,
+      predefinedTables = predefinedTables,
     )
 
     val sourceFiles = StringBuilder()

--- a/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/TestHeadlessParser.kt
+++ b/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/TestHeadlessParser.kt
@@ -1,6 +1,5 @@
 package com.alecstrong.sql.psi.test.fixtures
 
-import com.alecstrong.sql.psi.core.PredefinedTable
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.SqlCoreEnvironment
 import com.alecstrong.sql.psi.core.SqlFileBase
@@ -9,7 +8,9 @@ import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.icons.AllIcons
 import com.intellij.lang.Language
 import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.util.Key
 import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.tree.IFileElementType
 import java.io.File
 
@@ -17,7 +18,7 @@ object TestHeadlessParser {
   fun build(
     root: String,
     annotator: SqlAnnotationHolder,
-    predefinedTables: List<PredefinedTable> = emptyList(),
+    predefinedTables: List<String> = emptyList(),
     customInit: CoreApplicationEnvironment.() -> Unit = { },
   ): SqlCoreEnvironment {
     return build(listOf(File(root)), annotator, predefinedTables, customInit)
@@ -26,7 +27,7 @@ object TestHeadlessParser {
   fun build(
     sourceFolders: List<File>,
     annotator: SqlAnnotationHolder,
-    predefinedTables: List<PredefinedTable> = emptyList(),
+    predefinedTables: List<String> = emptyList(),
     customInit: CoreApplicationEnvironment.() -> Unit = { },
   ): SqlCoreEnvironment {
     val parserDefinition = TestParserDefinition(predefinedTables)
@@ -39,6 +40,7 @@ object TestHeadlessParser {
         initializeApplication {
           registerFileType(TestFileType, TestFileType.defaultExtension)
           registerParserDefinition(parserDefinition)
+
           customInit()
         }
       }
@@ -56,7 +58,7 @@ private object TestFileType : LanguageFileType(TestLanguage) {
   override fun getDescription() = "Test SQLite Language File"
 }
 
-private class TestParserDefinition(private val predefinedTables: List<PredefinedTable>) : SqlParserDefinition() {
+private class TestParserDefinition(private val predefinedTables: List<String>) : SqlParserDefinition() {
   override fun createFile(viewProvider: FileViewProvider) = TestFile(viewProvider, predefinedTables)
   override fun getFileNodeType() = FILE
   override fun getLanguage() = TestLanguage
@@ -66,7 +68,7 @@ private class TestParserDefinition(private val predefinedTables: List<Predefined
   }
 }
 
-private class TestFile(viewProvider: FileViewProvider, predefinedTables: List<PredefinedTable>) : SqlFileBase(viewProvider, TestLanguage, predefinedTables) {
+private class TestFile(viewProvider: FileViewProvider, private val predefinedTables: List<String>) : SqlFileBase(viewProvider, TestLanguage) {
   override fun getFileType() = TestFileType
   override val order = name.substringBefore(".${fileType.defaultExtension}").let { name ->
     if (name.all { it in '0'..'9' }) {
@@ -74,5 +76,22 @@ private class TestFile(viewProvider: FileViewProvider, predefinedTables: List<Pr
     } else {
       null
     }
+  }
+
+  override fun baseContributorFiles(): List<SqlFileBase> {
+    val base = super.baseContributorFiles()
+    if (getUserData(isPredefined) == Unit) {
+      return base
+    }
+    val factory = PsiFileFactory.getInstance(project)
+    return base + predefinedTables.map {
+      val file = factory.createFileFromText(TestLanguage, it) as SqlFileBase
+      file.putUserData(isPredefined, Unit)
+      file
+    }
+  }
+
+  companion object {
+    val isPredefined = Key.create<Unit>("isPredefined")
   }
 }

--- a/core/src/testFixtures/resources/fixtures/predefined/Dual.predefined
+++ b/core/src/testFixtures/resources/fixtures/predefined/Dual.predefined
@@ -1,3 +1,0 @@
-CREATE TABLE dual (
-  DUMMY TEXT NOT NULL
-);

--- a/core/src/testFixtures/resources/fixtures/predefined/Select.s
+++ b/core/src/testFixtures/resources/fixtures/predefined/Select.s
@@ -1,2 +1,0 @@
-SELECT *
-FROM dual;

--- a/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleFile.kt
+++ b/sample-core/src/main/kotlin/com/alecstrong/sql/psi/sample/core/SampleFile.kt
@@ -3,7 +3,7 @@ package com.alecstrong.sql.psi.sample.core
 import com.alecstrong.sql.psi.core.SqlFileBase
 import com.intellij.psi.FileViewProvider
 
-class SampleFile(viewProvider: FileViewProvider) : SqlFileBase(viewProvider, SampleLanguage, predefinedTables = emptyList()) {
+class SampleFile(viewProvider: FileViewProvider) : SqlFileBase(viewProvider, SampleLanguage) {
   override val order = name.substringBefore(".${fileType.defaultExtension}").let { name ->
     if (name.all { it in '0'..'9' }) {
       name.toLong()

--- a/test-fixtures/src/test/kotlin/com/alecstrong/sql/psi/test/fixtures/PassingPredefinedTablesTest.kt
+++ b/test-fixtures/src/test/kotlin/com/alecstrong/sql/psi/test/fixtures/PassingPredefinedTablesTest.kt
@@ -1,0 +1,31 @@
+package com.alecstrong.sql.psi.test.fixtures
+
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class PassingPredefinedTablesTest {
+  @Test
+  fun mirrorSqlDelight() {
+    val temp = Files.createTempDirectory("predefinedTest").toFile()
+    File(temp, "Test.s").writeText(
+      """
+      SELECT * FROM dual;
+      SELECT name FROM dual;
+      """.trimIndent(),
+    )
+    val env = TestHeadlessParser.build(
+      sourceFolders = listOf(temp),
+      annotator = { _, message ->
+        fail(message)
+      },
+      predefinedTables = listOf(
+        """
+        CREATE TABLE dual ( name TEXT );
+        """.trimIndent(),
+      ),
+    )
+    env.close()
+  }
+}


### PR DESCRIPTION
I dislike the (my) current implementation of system tables. We should use the `baseContributorFiles` method instead.