### PR TITLE
Expose loading fixtures from resources jar

### DIFF
--- a/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
+++ b/core/src/testFixtures/kotlin/com/alecstrong/sql/psi/test/fixtures/FixturesTest.kt
@@ -116,7 +116,7 @@ abstract class FixturesTest(
 
   companion object {
     init {
-      loadFolderFromResources("fixtures")
+      loadFolderFromResources("fixtures", target = File("build"))
     }
 
     @JvmStatic
@@ -126,10 +126,9 @@ abstract class FixturesTest(
   }
 }
 
-private fun Any.loadFolderFromResources(path: String) {
+fun Any.loadFolderFromResources(path: String, target: File) {
   val jarFile = File(javaClass.protectionDomain.codeSource.location.path)
-  val parentFile = File("build")
-  File(parentFile, path).apply { if (exists()) deleteRecursively() }
+  File(target, path).apply { if (exists()) deleteRecursively() }
 
   assert(jarFile.isFile)
 
@@ -140,9 +139,9 @@ private fun Any.loadFolderFromResources(path: String) {
     val name: String = entry.name
     if (name.startsWith("$path/")) { // filter according to the path
       if (entry.isDirectory) {
-        File(parentFile, entry.name).mkdir()
+        File(target, entry.name).mkdir()
       } else {
-        File(parentFile, entry.name).apply {
+        File(target, entry.name).apply {
           createNewFile()
           jar.getInputStream(entry).use {
             it.copyTo(outputStream())


### PR DESCRIPTION
Reading fixtures from resources is also needed for each dialect https://github.com/cashapp/sqldelight/pull/4511. Current workaround is copy pasta this private function until a new sql-psi release is out.