### PR TITLE
Fix 550 Insert Select expr

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -375,7 +375,7 @@ table_or_subquery ::= ( [ database_name DOT ] table_name [ [ AS ] table_alias ] 
 }
 result_column ::= ( MULTIPLY
                   | table_name DOT MULTIPLY
-                  | expr [ [ AS ] column_alias ] ) {
+                  | expr [ AS column_alias | column_alias ] ) {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.ResultColumnMixin"
   implements = [
     "com.alecstrong.sql.psi.core.psi.QueryElement";


### PR DESCRIPTION
Split the optional AS rule - the existing grammar was not matching 

fixes #550 

TODO Tests ( I would need to create tests for specific dialects that support RETURNING) - 
as this SQL is only valid on Sqlite 3.37( + higher)  and PostgreSql

``` sql
INSERT INTO answers(id, answer)
SELECT 42, 'forty two'
RETURNING *;
```