### PR TITLE
Refactor loading fixtures from jar resources

### DIFF
--- a/core/src/test/kotlin/com/alecstrong/sql/psi/core/PassingPredefinedTablesTest.kt
+++ b/core/src/test/kotlin/com/alecstrong/sql/psi/core/PassingPredefinedTablesTest.kt
@@ -1,5 +1,6 @@
-package com.alecstrong.sql.psi.test.fixtures
+package com.alecstrong.sql.psi.core
 
+import com.alecstrong.sql.psi.test.fixtures.TestHeadlessParser
 import org.junit.Assert.fail
 import org.junit.Test
 import java.io.File


### PR DESCRIPTION
KGP 1.9.20 changes the resource loading behavior in tests. Previously, the resources were always loaded from jar, resulting in the creation of the jar first. Now the resources are added as file references, without creating the jar.