### PR TITLE
Fix multiple columns with same name error for JOIN USING

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/JoinClauseMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/JoinClauseMixin.kt
@@ -35,7 +35,8 @@ internal abstract class JoinClauseMixin(
                       column is PsiNamedElement && column.name!! in subquery.queryExposed()
                         .flatMap { it.columns }
                         .mapNotNull { (it.element as? PsiNamedElement)?.name }
-                    },
+                    }
+                    .distinctBy { (it.element as? PsiNamedElement)?.name ?: it },
                 ),
               )
             }

--- a/core/src/testFixtures/resources/fixtures/adjacent-columns/Test.s
+++ b/core/src/testFixtures/resources/fixtures/adjacent-columns/Test.s
@@ -16,3 +16,8 @@ WHERE id IN (
     LEFT JOIN bar ON foo.id = bar.id
     LEFT JOIN baz ON foo.id = baz.id
 );
+
+SELECT *
+FROM foo
+JOIN bar USING (id)
+JOIN baz USING (id);


### PR DESCRIPTION
Fixes https://github.com/cashapp/sqldelight/issues/4767

Not sure if this is the correct approach here, but I couldn't think of any other way to do it with changing other behavior.