### PR TITLE
Remove useless dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -17,7 +17,6 @@ sourceSets {
 dependencies {
   compileOnly libs.bundles.intelliJ
 
-  testFixturesApi project(":core")
   testFixturesApi libs.junit
   testFixturesCompileOnly libs.bundles.intelliJ
 


### PR DESCRIPTION
The main source/project is already added as testFixturesApi dependency by Gradle.