### PR TITLE
Update JoinClauseMixin to support more ANSI SQL joins

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
@@ -184,7 +184,6 @@ STRING=('([^'])*'|\"([^\"])*\")
   "HAVING"               { return HAVING; }
   "INDEXED"              { return INDEXED; }
   "NATURAL"              { return NATURAL; }
-  "LATERAL"              { return LATERAL; }
   "LEFT"                 { return LEFT; }
   "RIGHT"                { return RIGHT; }
   "FULL"                 { return FULL; }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/SqlLexer.flex
@@ -184,7 +184,10 @@ STRING=('([^'])*'|\"([^\"])*\")
   "HAVING"               { return HAVING; }
   "INDEXED"              { return INDEXED; }
   "NATURAL"              { return NATURAL; }
+  "LATERAL"              { return LATERAL; }
   "LEFT"                 { return LEFT; }
+  "RIGHT"                { return RIGHT; }
+  "FULL"                 { return FULL; }
   "OUTER"                { return OUTER; }
   "INNER"                { return INNER; }
   "CROSS"                { return CROSS; }

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -387,7 +387,6 @@ result_column ::= ( MULTIPLY
 left_join_operator ::= LEFT
 right_join_operator ::= RIGHT
 full_join_operator ::= FULL
-lateral_join_modifier ::= LATERAL
 
 join_operator ::= ( COMMA
                   | [ NATURAL ] [ left_join_operator [ OUTER ] | INNER | CROSS ] JOIN )

--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -383,8 +383,14 @@ result_column ::= ( MULTIPLY
     "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   ]
 }
+
+left_join_operator ::= LEFT
+right_join_operator ::= RIGHT
+full_join_operator ::= FULL
+lateral_join_modifier ::= LATERAL
+
 join_operator ::= ( COMMA
-                  | [ NATURAL ] [ LEFT [ OUTER ] | INNER | CROSS ] JOIN )
+                  | [ NATURAL ] [ left_join_operator [ OUTER ] | INNER | CROSS ] JOIN )
 join_constraint ::= [ ON expr | USING LP column_name ( COMMA column_name ) * RP ]
 ordering_term ::= expr [ COLLATE collation_name ] [ ASC | DESC ] {
   mixin = "com.alecstrong.sql.psi.core.psi.mixins.OrderByMixin"


### PR DESCRIPTION
🦶Initial step to support https://github.com/cashapp/sqldelight/issues/5086

Add Ansi Sql join operators `RIGHT` and `FULL` e.g Now supported in https://www.sqlite.org/releaselog/3_39_0.html

`LATERAL` modifier not included, as works in two different ways (table/subquery and join) and should be implemented as a separate feature

These are added as forward declarations in the `SqlLexer.flex` that are needed for dialects to override

🏰  Keep core grammar with `LEFT` join

This allows the existing dialects to work with `LEFT` join and enables dialects to add `RIGHT`, `FULL` where supported, e.g PostgreSql and latest Sqlite dialect

e.g Postgresql.bnf would override the core `join_operator` and adds `right_join_operator`

📸 Tested snapshot build with SqlDelight branch as this appears to work

```
join_operator ::= ( COMMA
                  | [ NATURAL ] [ ( {left_join_operator} | {right_join_operator} | {full_join_operator} ) [ OUTER ] | INNER | CROSS ] JOIN ) {
  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlJoinOperatorImpl"
  implements = "com.alecstrong.sql.psi.core.psi.SqlJoinOperator"
  override = true
}
```