### PR TITLE
Include the environment dependency for core test fixtures

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,8 +18,8 @@ dependencies {
   compileOnly libs.bundles.intelliJ
 
   testFixturesApi libs.junit
+  testFixturesApi projects.environment
   testFixturesCompileOnly libs.bundles.intelliJ
-  testFixturesCompileOnly projects.environment
 
   testImplementation libs.junit
   testImplementation libs.truth


### PR DESCRIPTION
Otherwise downstream doesn't work @hfhbd 