### PR TITLE
Add Optional NOT to function expression

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/sql.bnf
@@ -277,7 +277,7 @@ binary_and_expr ::= expr AND expr {
 binary_or_expr ::= expr OR expr {
   implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryExpr"
 }
-function_expr ::= function_name LP [ [ DISTINCT ] expr ( ( COMMA | FROM | FOR | SEPARATOR ) expr ) * | MULTIPLY ] RP
+function_expr ::= [ NOT ] function_name LP [ [ DISTINCT ] expr ( ( COMMA | FROM | FOR | SEPARATOR ) expr ) * | MULTIPLY ] RP
 paren_expr ::= LP expr RP {
   pin = 1
 }

--- a/core/src/testFixtures/resources/fixtures/not-function-expr/Test.s
+++ b/core/src/testFixtures/resources/fixtures/not-function-expr/Test.s
@@ -1,0 +1,15 @@
+CREATE TABLE test (
+  test_id INTEGER
+);
+
+SELECT
+  test_id
+FROM
+  test
+GROUP BY
+  test_id
+HAVING
+ NOT COALESCE(TRUE, FALSE);
+
+SELECT NOT COALESCE(TRUE, FALSE) FROM test;
+


### PR DESCRIPTION
fixes #638 

This allows boolean functions to be negated

More useful for ANSI SQL aggregate  function `every` (though not supported by Sqlite)

```sql
SELECT
  column1,
  column2,
  COUNT(*) AS count
FROM
  table_name
GROUP BY
  column1,
  column2
HAVING
  NOT every(column1 IS NOT NULL);
```

This could be fixed in the PostgreSql dialect, as there are more uses for boolean functions, but is applicable to all dialects