### PR TITLE
Update TableNameMixin

### DIFF
--- a/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateViewMixin.kt
+++ b/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateViewMixin.kt
@@ -35,6 +35,8 @@ internal abstract class CreateViewMixin(
   }
 
   override fun modifySchema(schema: Schema) {
+    schema.forType<TableElement>().remove(name())
+    schema.forType<SqlCreateViewStmt>().remove(name())
     schema.put<TableElement>(this)
     schema.put<SqlCreateViewStmt>(this)
   }


### PR DESCRIPTION
Support https://github.com/cashapp/sqldelight/issues/5407 CREATE OR REPLACE VIEW

Adding to SQL-PSI as best supported here to update the annotation check for EXISTS and REPLACE nodes, so that views can be replaced multiple times in migration files as scheme elements can only use a single CREATE statement and will fail with `Table already defined with name $name`. 

A dialect (PostgreSql) will define CREATE OR REPLACE in the dialect grammar and has no effect in SQL-PSI or dialects that don't support CREATE OR REPLACE

Note:
The PostgreSql dialect will have to handle the possible addition of columns so `CREATE OR REPLACE ` will have to behave like a cross-between `IF NOT EXISTS` and `ALTER TABLE` 

Intentionally added  `remove` to `CreateViewMixin` as it allows the columns to be replaced

``` kotlin
override fun modifySchema(schema: Schema) {
    schema.forType<TableElement>().remove(name())
    schema.forType<SqlCreateViewStmt>().remove(name())
    schema.put<TableElement>(this)
    schema.put<SqlCreateViewStmt>(this)
  }
```

Testing with PostgreSql dialect using sql-psi snapshot version 
